### PR TITLE
Change `&(dyn Any + Send)` to `&dyn Any`.

### DIFF
--- a/src/ParsedPanic.rs
+++ b/src/ParsedPanic.rs
@@ -36,7 +36,7 @@ impl<'panic_info> ParsedPanic<'panic_info>
 	}
 
 	#[inline(always)]
-	fn parse(panic_payload: &'panic_info (dyn Any + Send), location: Option<&'panic_info Location<'panic_info>>) -> Self
+	fn parse(panic_payload: &'panic_info dyn Any, location: Option<&'panic_info Location<'panic_info>>) -> Self
 	{
 		let thread_causing_panic = thread::current();
 

--- a/src/SimpleTerminate.rs
+++ b/src/SimpleTerminate.rs
@@ -20,7 +20,7 @@ impl<PPEL: ParsedPanicErrorLogger> Terminate for SimpleTerminate<PPEL>
 	}
 
 	#[inline(always)]
-	fn begin_termination_due_to_irrecoverable_error(&self, panic_payload: &(dyn Any + Send), location: Option<&Location>)
+	fn begin_termination_due_to_irrecoverable_error(&self, panic_payload: &dyn Any, location: Option<&Location>)
 	{
 		self.compare_and_swap(Self::PanicTerminate);
 		let parsed_panic = ParsedPanic::parse(panic_payload, location);

--- a/src/Terminate.rs
+++ b/src/Terminate.rs
@@ -23,7 +23,7 @@ pub trait Terminate: Send + Sync
 	///
 	/// `irrecoverable_error` is the same type as `PanicInfo.payload`.
 	/// `location` can be `None`.
-	fn begin_termination_due_to_irrecoverable_error(&self, irrecoverable_error: &(dyn Any + Send), location: Option<&Location>);
+	fn begin_termination_due_to_irrecoverable_error(&self, irrecoverable_error: &dyn Any, location: Option<&Location>);
 
 	/// Should finish.
 	fn should_finish(&self) -> bool;

--- a/src/panic_payload_to_cause.rs
+++ b/src/panic_payload_to_cause.rs
@@ -4,7 +4,7 @@
 
 /// What caused the panic?
 #[inline(always)]
-pub fn panic_payload_to_cause<'panic_info>(panic_payload: &'panic_info (dyn Any + 'static + Send)) -> &'panic_info str
+pub fn panic_payload_to_cause<'panic_info>(panic_payload: &'panic_info dyn Any) -> &'panic_info str
 {
 	if panic_payload.is::<String>()
 	{


### PR DESCRIPTION
This changes `&(dyn Any + Send)` to `&dyn Any`, because the `Send` trait is a useless restriction for references. (`&(dyn Any + Send)` implicitly converts to `&dyn Any`, but not the other way around.)

See https://github.com/rust-lang/rust/pull/110799